### PR TITLE
Update dashboard datasource and variable

### DIFF
--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -1,1027 +1,1014 @@
 {
-    "__inputs": [
-      {
-        "name": "DS_GRAFANA-SNOWFLAKE-DATASOURCE",
-        "label": "grafana-snowflake-datasource",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "grafana-snowflake-datasource",
-        "pluginName": "Snowflake"
-      }
-    ],
-    "__elements": {},
-    "__requires": [
-      {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "11.0.0-67746"
-      },
-      {
-        "type": "datasource",
-        "id": "grafana-snowflake-datasource",
-        "name": "Snowflake",
-        "version": "1.8.1"
-      },
-      {
-        "type": "panel",
-        "id": "logs",
-        "name": "Logs",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "stat",
-        "name": "Stat",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "table",
-        "name": "Table",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "timeseries",
-        "name": "Time series",
-        "version": ""
-      }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA_SNOWFLAKE_DATASOURCE",
+      "label": "grafana-snowflake-datasource",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-snowflake-datasource",
+      "pluginName": "Snowflake"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0-67746"
     },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": null,
-    "links": [],
-    "liveNow": false,
-    "panels": [
+    {
+      "type": "datasource",
+      "id": "grafana-snowflake-datasource",
+      "name": "Snowflake",
+      "version": "1.8.1"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
       {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 4,
-        "panels": [],
-        "type": "row"
-      },
-      {
+        "builtIn": 1,
         "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          "type": "grafana",
+          "uid": "-- Grafana --"
         },
-        "description": "",
-        "gridPos": {
-          "h": 6,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 1,
-        "options": {
-          "dedupStrategy": "none",
-          "enableLogDetails": true,
-          "prettifyLogMessage": true,
-          "showCommonLabels": false,
-          "showLabels": false,
-          "showTime": true,
-          "sortOrder": "Descending",
-          "wrapLogMessage": false
-        },
-        "pluginVersion": "11.0.0-67429",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 2,
-            "rawSql": "SELECT TOP ${number_of_logs} TIMESTAMP, CONCAT(RECORD:\"severity_text\", ': ', VALUE) AS LOG, * EXCLUDE (TIMESTAMP, VALUE, RECORD)\n  FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs",
-        "type": "logs"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "noValue": "...",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "locale"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Total Queries"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#1d8bb7",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cache Hits"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#4fb07ce6",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cache Miss"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#b59151eb",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Prefetch"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#4fb07ce6",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Expired"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#a871a7f0",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 3,
-          "x": 0,
-          "y": 7
-        },
-        "id": 2,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(*) AS \" Number of Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": 1800000,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "noValue": "0",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 21,
-          "x": 3,
-          "y": 7
-        },
-        "id": 9,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "10.4.0-65875",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT DATE_TRUNC(${time_series_division:singlequote}, \"TIMESTAMP\") AS \"Time\", COUNT_IF(RECORD:\"severity_text\"='TRACE') AS \"TRACE\", COUNT_IF(RECORD:\"severity_text\"='DEBUG') AS \"DEBUG\", COUNT_IF(RECORD:\"severity_text\"='INFO') AS \"INFO\", COUNT_IF(RECORD:\"severity_text\"='WARN') AS \"WARN\", COUNT_IF(RECORD:\"severity_text\"='ERROR') AS \"ERROR\", COUNT_IF(RECORD:\"severity_text\"='FATAL') AS \"FATAL\"\n\tFROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP ASC)\n\tGROUP BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\")\n\tORDER BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\");",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs over Time",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 3,
-          "x": 0,
-          "y": 16
-        },
-        "id": 7,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"db.user\") AS \"Unique DB Users in Logs\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-            "refId": "A"
-          }
-        ],
-        "title": "Users",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "mode": "gradient",
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 21,
-          "x": 3,
-          "y": 16
-        },
-        "id": 11,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "enablePagination": false,
-            "fields": [],
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": []
-        },
-        "pluginVersion": "11.0.0-67746",
-        "repeat": "severity_sort_user",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"db.user\"::string AS \"User\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"db.user\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by User",
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 3,
-          "x": 0,
-          "y": 23
-        },
-        "id": 19,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\") AS \"Number of Unique Warehouses in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-            "refId": "A"
-          }
-        ],
-        "title": "Warehouses",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": true,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 21,
-          "x": 3,
-          "y": 23
-        },
-        "id": 20,
-        "maxPerRow": 3,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"::string AS \"Warehouse Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC) \n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by Warehouse",
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 3,
-          "x": 0,
-          "y": 30
-        },
-        "id": 18,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\") AS \"Number of Unique Executable Names in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-            "refId": "A"
-          }
-        ],
-        "title": "Executables",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": true,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 21,
-          "x": 3,
-          "y": 30
-        },
-        "id": 14,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "repeat": "severity_sort_executable",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.executable.name\"::string AS \"Executable Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.executable.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by Executable",
-        "type": "table"
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "refresh": "",
-    "schemaVersion": 39,
-    "tags": [],
-    "templating": {
-      "list": [
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "panels": [],
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.0.0-67429",
+      "targets": [
         {
-          "current": {
-            "selected": false,
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 2,
+          "rawSql": "SELECT TOP ${number_of_logs} TIMESTAMP, CONCAT(RECORD:\"severity_text\", ': ', VALUE) AS LOG, * EXCLUDE (TIMESTAMP, VALUE, RECORD)\n  FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "...",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Queries"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#1d8bb7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Hits"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4fb07ce6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Miss"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#b59151eb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Prefetch"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4fb07ce6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expired"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#a871a7f0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(*) AS \" Number of Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": 1800000,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 21,
+        "x": 3,
+        "y": 7
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0-65875",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT DATE_TRUNC(${time_series_division:singlequote}, \"TIMESTAMP\") AS \"Time\", COUNT_IF(RECORD:\"severity_text\"='TRACE') AS \"TRACE\", COUNT_IF(RECORD:\"severity_text\"='DEBUG') AS \"DEBUG\", COUNT_IF(RECORD:\"severity_text\"='INFO') AS \"INFO\", COUNT_IF(RECORD:\"severity_text\"='WARN') AS \"WARN\", COUNT_IF(RECORD:\"severity_text\"='ERROR') AS \"ERROR\", COUNT_IF(RECORD:\"severity_text\"='FATAL') AS \"FATAL\"\n\tFROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP ASC)\n\tGROUP BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\")\n\tORDER BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\");",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"db.user\") AS \"Unique DB Users in Logs\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+          "refId": "A"
+        }
+      ],
+      "title": "Users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 21,
+        "x": 3,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": [],
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeat": "severity_sort_user",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"db.user\"::string AS \"User\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"db.user\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by User",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 23
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\") AS \"Number of Unique Warehouses in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+          "refId": "A"
+        }
+      ],
+      "title": "Warehouses",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": true,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 21,
+        "x": 3,
+        "y": 23
+      },
+      "id": 20,
+      "maxPerRow": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"::string AS \"Warehouse Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC) \n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Warehouse",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 0,
+        "y": 30
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\") AS \"Number of Unique Executable Names in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executables",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": true,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 21,
+        "x": 3,
+        "y": 30
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeat": "severity_sort_executable",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.executable.name\"::string AS \"Executable Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.executable.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Executable",
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+          "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
+        },
+        "description": "The name of the Event Table to query telemetry information from.",
+        "hide": 0,
+        "label": "Event Table",
+        "name": "event_table",
+        "options": [
+          {
+            "selected": true,
             "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
             "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-          },
-          "description": "The name of the Event Table to query telemetry information from.",
-          "hide": 0,
-          "label": "Event Table",
-          "name": "event_table",
-          "options": [
-            {
-              "selected": true,
-              "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-              "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-            }
-          ],
-          "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-          "skipUrlSync": false,
-          "type": "textbox"
+          }
+        ],
+        "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "100",
+          "value": "100"
         },
-        {
-          "current": {
-            "selected": false,
+        "description": "10",
+        "hide": 0,
+        "label": "Number of Logs",
+        "name": "number_of_logs",
+        "options": [
+          {
+            "selected": true,
             "text": "100",
             "value": "100"
-          },
-          "description": "10",
-          "hide": 0,
-          "label": "Number of Logs",
-          "name": "number_of_logs",
-          "options": [
-            {
-              "selected": true,
-              "text": "100",
-              "value": "100"
-            }
-          ],
-          "query": "100",
-          "skipUrlSync": false,
-          "type": "textbox"
+          }
+        ],
+        "query": "100",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Users",
-          "multi": true,
-          "name": "users",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Users",
+        "multi": true,
+        "name": "users",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Warehouses",
-          "multi": true,
-          "name": "warehouses",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Executables",
-          "multi": true,
-          "name": "executables",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Warehouses",
+        "multi": true,
+        "name": "warehouses",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);"
         },
-        {
-          "allValue": "",
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Severity Levels",
-          "multi": true,
-          "name": "severity_levels",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
-        {
-          "current": {
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Executables",
+        "multi": true,
+        "name": "executables",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
+        },
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+        },
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Severity Levels",
+        "multi": true,
+        "name": "severity_levels",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
+        },
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "HOUR",
+          "value": "HOUR"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Time Interval",
+        "multi": false,
+        "name": "time_series_division",
+        "options": [
+          {
+            "selected": false,
+            "text": "SECOND",
+            "value": "SECOND"
+          },
+          {
+            "selected": false,
+            "text": "MINUTE",
+            "value": "MINUTE"
+          },
+          {
             "selected": true,
             "text": "HOUR",
             "value": "HOUR"
           },
-          "hide": 0,
-          "includeAll": false,
-          "label": "Time Interval",
-          "multi": false,
-          "name": "time_series_division",
-          "options": [
-            {
-              "selected": false,
-              "text": "SECOND",
-              "value": "SECOND"
-            },
-            {
-              "selected": false,
-              "text": "MINUTE",
-              "value": "MINUTE"
-            },
-            {
-              "selected": true,
-              "text": "HOUR",
-              "value": "HOUR"
-            },
-            {
-              "selected": false,
-              "text": "DAY",
-              "value": "DAY"
-            },
-            {
-              "selected": false,
-              "text": "MONTH",
-              "value": "MONTH"
-            },
-            {
-              "selected": false,
-              "text": "YEAR",
-              "value": "YEAR"
-            }
-          ],
-          "query": "SECOND,MINUTE,HOUR,DAY,MONTH,YEAR",
-          "queryValue": "",
-          "skipUrlSync": false,
-          "type": "custom"
-        }
-      ]
-    },
-    "time": {
-      "from": "2024-03-04T21:30:00.500Z",
-      "to": "2024-03-05T11:29:58.500Z"
-    },
-    "timeRangeUpdatedDuringEditOrView": false,
-    "timepicker": {},
-    "timezone": "",
-    "title": "Logs Dashboard",
-    "version": 21,
-    "weekStart": ""
-  }
+          {
+            "selected": false,
+            "text": "DAY",
+            "value": "DAY"
+          },
+          {
+            "selected": false,
+            "text": "MONTH",
+            "value": "MONTH"
+          },
+          {
+            "selected": false,
+            "text": "YEAR",
+            "value": "YEAR"
+          }
+        ],
+        "query": "SECOND,MINUTE,HOUR,DAY,MONTH,YEAR",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "2024-03-04T21:30:00.500Z",
+    "to": "2024-03-05T11:29:58.500Z"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "",
+  "title": "Logs Dashboard",
+  "uid": "431d22e3d526",
+  "version": 21,
+  "weekStart": ""
+}

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -15,13 +15,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.0.0-67746"
+      "version": "11.1.0-70903"
     },
     {
       "type": "datasource",
       "id": "grafana-snowflake-datasource",
       "name": "Snowflake",
-      "version": "1.8.1"
+      "version": "1.7.1"
     },
     {
       "type": "panel",
@@ -235,7 +235,9 @@
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -243,7 +245,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -393,7 +395,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -401,7 +405,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -484,13 +488,15 @@
           "countRows": false,
           "enablePagination": false,
           "fields": [],
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "repeat": "severity_sort_user",
       "repeatDirection": "h",
       "targets": [
@@ -547,7 +553,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -555,7 +563,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -637,12 +645,14 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "repeatDirection": "h",
       "targets": [
         {
@@ -673,8 +683,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -698,7 +707,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -706,7 +717,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -747,8 +758,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -787,12 +797,14 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "repeat": "severity_sort_executable",
       "repeatDirection": "h",
       "targets": [
@@ -816,25 +828,49 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-          "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
         },
-        "description": "The name of the Event Table to query telemetry information from.",
-        "hide": 0,
-        "label": "Event Table",
-        "name": "event_table",
-        "options": [
-          {
-            "selected": true,
-            "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-            "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-          }
-        ],
-        "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+        "definition": "grafana-snowflake-datasource Query :  show parameters like 'event_table' in account;\n",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "show_event_table",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "show parameters like 'event_table' in account;\n"
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "textbox"
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        },
+        "definition": "grafana-snowflake-datasource Query :  select \"value\" \nfrom table(result_scan(last_query_id()))\n--where '${show_event_table}' is not null;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "active_event_table",
+        "multi": false,
+        "name": "event_table",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "select \"value\" \nfrom table(result_scan(last_query_id()))\n--where '${show_event_table}' is not null;"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
         "current": {
@@ -952,7 +988,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "HOUR",
           "value": "HOUR"
         },
@@ -1007,8 +1043,8 @@
   "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "",
-  "title": "Logs Dashboard",
-  "uid": "431d22e3d526",
-  "version": 21,
+  "title": "Logs v2",
+  "uid": "431d22e3d5262",
+  "version": 5,
   "weekStart": ""
 }

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -1,7 +1,7 @@
 {
   "__inputs": [
     {
-      "name": "DS_GRAFANA-SNOWFLAKE-DATASOURCE",
+      "name": "DS_GRAFANA_SNOWFLAKE_DATASOURCE",
       "label": "grafana-snowflake-datasource",
       "description": "",
       "type": "datasource",
@@ -212,9 +212,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
+          "calcs": ["mean"],
           "fields": "",
           "values": false
         },
@@ -227,7 +225,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 1,
           "rawSql": "SELECT\n    count(DISTINCT FUNCTION_NAME)\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS\nWHERE TRUE \n  AND DELETED IS NULL\n  AND FUNCTION_CATALOG = '${database}';",
@@ -271,9 +269,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
+          "calcs": ["mean"],
           "fields": "",
           "values": false
         },
@@ -286,7 +282,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 1,
           "rawSql": "SELECT\n    count(DISTINCT PROCEDURE_NAME)\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES\nWHERE TRUE \n  AND DELETED IS NULL\n  AND PROCEDURE_CATALOG = '${database}';",
@@ -342,9 +338,7 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true
@@ -354,7 +348,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 1,
           "rawSql": "SELECT DISTINCT\n    'PROCEDURE' as  type, PROCEDURE_NAME as name, PROCEDURE_LANGUAGE as language, RUNTIME_VERSION, LAST_ALTERED\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES\nWHERE TRUE \n  AND DELETED IS NULL\n  AND PROCEDURE_CATALOG = '${database}'\n  AND PROCEDURE_SCHEMA = '${schema}'\n  AND PROCEDURE_LANGUAGE in ('PYTHON', 'JAVA', 'JAVASCRIPT')\nUNION\nSELECT\n    DISTINCT 'FUNCTION' as  type, FUNCTION_NAME as name, FUNCTION_LANGUAGE as language, RUNTIME_VERSION, LAST_ALTERED\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS\nWHERE TRUE \n  AND DELETED IS NULL\n  AND FUNCTION_CATALOG = '${database}'\n  AND FUNCTION_SCHEMA = '${schema}'\n  AND FUNCTION_LANGUAGE in ('PYTHON', 'JAVA', 'JAVASCRIPT')\nORDER BY 1, 2;",
@@ -414,7 +408,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_SNOWFLAKE}"
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
       },
       "fieldConfig": {
         "defaults": {
@@ -494,7 +488,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 0,
           "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as memory_usage_bytes\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    value::INT as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${memory_usage}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;",
@@ -507,7 +501,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_SNOWFLAKE}"
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
       },
       "fieldConfig": {
         "defaults": {
@@ -587,7 +581,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 0,
           "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as CPU_UTIL_PCT\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp, \n    value::DOUBLE as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${cpu_util}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;\n  ",
@@ -626,7 +620,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  show parameters like 'event_table' in account;",
         "hide": 2,
@@ -649,7 +643,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  SELECT \"value\" \nFROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))\nwhere '${show_event_table}' is not null;\n",
         "hide": 0,
@@ -711,7 +705,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  select distinct database_name from snowflake.account_usage.databases where DELETED is null;",
         "hide": 0,
@@ -734,7 +728,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  select schema_name from snowflake.account_usage.schemata \nwhere deleted is null\nand catalog_name = '${database}';",
         "hide": 0,

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -29,7 +29,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.1.0-69622"
+      "version": "11.1.0-69950"
     },
     {
       "type": "datasource",
@@ -118,7 +118,7 @@
         "content": "## Snowpark Metrics Dashboard\n\nThis dashboard visualizes Snowpark-related metrics in the Snowflake Event Table. \nMany operations require the queryer to have the `ACCOUNTADMIN` role.\n\nTo do this securely, you can create a new grafana datasource that has a user with the `ACCOUNTADMIN` role, and select that datasource in the variables above.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -165,7 +165,7 @@
         "content": "Select the `Database` and `Schema` variables to view the active functions and procedures.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -222,7 +222,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -281,7 +281,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -349,7 +349,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -398,7 +398,7 @@
         "content": "Fill in the `Function Name` variable to view Memory and CPU metrics for this function or procedure.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -458,7 +458,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -496,7 +497,7 @@
             "uid": "${DS_SNOWFLAKE}"
           },
           "format": 0,
-          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as memory_usage_bytes\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    CASE \n      WHEN record['value_type'] = 'INT' THEN value::INT\n      WHEN record['value_type'] = 'DOUBLE' THEN value::DOUBLE\n    END as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${memory_usage}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;",
+          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as memory_usage_bytes\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    value::INT as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${memory_usage}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;",
           "refId": "A"
         }
       ],
@@ -546,13 +547,12 @@
             }
           },
           "mappings": [],
-          "max": 1,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -590,7 +590,7 @@
             "uid": "${DS_SNOWFLAKE}"
           },
           "format": 0,
-          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as CPU_UTIL_PCT\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    CASE \n      WHEN record['value_type'] = 'INT' THEN value::INT\n      WHEN record['value_type'] = 'DOUBLE' THEN value::DOUBLE\n    END as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${cpu_util}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;\n  ",
+          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as CPU_UTIL_PCT\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp, \n    value::DOUBLE as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${cpu_util}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;\n  ",
           "refId": "A"
         }
       ],
@@ -784,6 +784,6 @@
   "timezone": "",
   "title": "Snowpark Metrics Dashboard",
   "uid": "fdivgoharm0owc",
-  "version": 67,
+  "version": 68,
   "weekStart": ""
 }

--- a/open_source/logs.json
+++ b/open_source/logs.json
@@ -1,1022 +1,1028 @@
 {
-    "__inputs": [
-      {
-        "name": "DS_MICHELIN-SNOWFLAKE-DATASOURCE",
-        "label": "michelin-snowflake-datasource",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "michelin-snowflake-datasource",
-        "pluginName": "Snowflake"
-      }
-    ],
-    "__elements": {},
-    "__requires": [
-      {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "10.3.3"
-      },
-      {
-        "type": "panel",
-        "id": "logs",
-        "name": "Logs",
-        "version": ""
-      },
-      {
-        "type": "datasource",
-        "id": "michelin-snowflake-datasource",
-        "name": "Snowflake",
-        "version": "1.5.0"
-      },
-      {
-        "type": "panel",
-        "id": "stat",
-        "name": "Stat",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "table",
-        "name": "Table",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "timeseries",
-        "name": "Time series",
-        "version": ""
-      }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA_SNOWFLAKE_DATASOURCE",
+      "label": "grafana-snowflake-datasource",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "michelin-snowflake-datasource",
+      "pluginName": "Snowflake"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0-67746"
     },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": null,
-    "links": [],
-    "liveNow": false,
-    "panels": [
+    {
+      "type": "datasource",
+      "id": "grafana-snowflake-datasource",
+      "name": "Snowflake",
+      "version": "1.8.1"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
       {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 4,
-        "panels": [],
-        "type": "row"
-      },
-      {
+        "builtIn": 1,
         "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
+          "type": "grafana",
+          "uid": "-- Grafana --"
         },
-        "description": "",
-        "gridPos": {
-          "h": 6,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 1,
-        "options": {
-          "dedupStrategy": "none",
-          "enableLogDetails": true,
-          "prettifyLogMessage": true,
-          "showCommonLabels": false,
-          "showLabels": false,
-          "showTime": true,
-          "sortOrder": "Descending",
-          "wrapLogMessage": false
-        },
-        "pluginVersion": "11.0.0-67429",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 2,
-            "queryText": "SELECT TOP ${number_of_logs} TIMESTAMP, CONCAT(RECORD:\"severity_text\", ': ', VALUE) AS LOG, * EXCLUDE (TIMESTAMP, VALUE, RECORD)\n  FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs",
-        "type": "logs"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "noValue": "...",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "locale",
-            "unitScale": true
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Total Queries"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#1d8bb7",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cache Hits"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#4fb07ce6",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cache Miss"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#b59151eb",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Prefetch"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#4fb07ce6",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Expired"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#a871a7f0",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 3,
-          "x": 0,
-          "y": 7
-        },
-        "id": 2,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "10.3.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT COUNT(*) AS \" Number of Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": 1800000,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "noValue": "0",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unitScale": true
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 21,
-          "x": 3,
-          "y": 7
-        },
-        "id": 9,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "10.4.0-65875",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT DATE_TRUNC(${time_series_division:singlequote}, \"TIMESTAMP\") AS \"Time\", COUNT_IF(RECORD:\"severity_text\"='TRACE') AS \"TRACE\", COUNT_IF(RECORD:\"severity_text\"='DEBUG') AS \"DEBUG\", COUNT_IF(RECORD:\"severity_text\"='INFO') AS \"INFO\", COUNT_IF(RECORD:\"severity_text\"='WARN') AS \"WARN\", COUNT_IF(RECORD:\"severity_text\"='ERROR') AS \"ERROR\", COUNT_IF(RECORD:\"severity_text\"='FATAL') AS \"FATAL\"\n\tFROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP ASC)\n\tGROUP BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\")\n\tORDER BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\");",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs over Time",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unitScale": true
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 3,
-          "x": 0,
-          "y": 16
-        },
-        "id": 7,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "10.3.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"db.user\") AS \"Unique DB Users in Logs\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-            "refId": "A"
-          }
-        ],
-        "title": "Users",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none",
-            "unitScale": true
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "mode": "gradient",
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 21,
-          "x": 3,
-          "y": 16
-        },
-        "id": 11,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "enablePagination": false,
-            "fields": [],
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": []
-        },
-        "pluginVersion": "10.3.3",
-        "repeat": "severity_sort_user",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT RESOURCE_ATTRIBUTES:\"db.user\"::string AS \"User\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"db.user\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by User",
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unitScale": true
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 3,
-          "x": 0,
-          "y": 23
-        },
-        "id": 19,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "10.3.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\") AS \"Number of Unique Warehouses in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-            "refId": "A"
-          }
-        ],
-        "title": "Warehouses",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": true,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none",
-            "unitScale": true
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 21,
-          "x": 3,
-          "y": 23
-        },
-        "id": 20,
-        "maxPerRow": 3,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true
-        },
-        "pluginVersion": "10.3.3",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"::string AS \"Warehouse Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC) \n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by Warehouse",
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unitScale": true
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 3,
-          "x": 0,
-          "y": 30
-        },
-        "id": 18,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "10.3.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\") AS \"Number of Unique Executable Names in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-            "refId": "A"
-          }
-        ],
-        "title": "Executables",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "michelin-snowflake-datasource",
-          "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": true,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none",
-            "unitScale": true
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 21,
-          "x": 3,
-          "y": 30
-        },
-        "id": 14,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true
-        },
-        "pluginVersion": "10.3.3",
-        "repeat": "severity_sort_executable",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "michelin-snowflake-datasource",
-              "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "queryText": "SELECT RESOURCE_ATTRIBUTES:\"snow.executable.name\"::string AS \"Executable Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.executable.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by Executable",
-        "type": "table"
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "refresh": "",
-    "schemaVersion": 39,
-    "tags": [],
-    "templating": {
-      "list": [
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "panels": [],
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.0.0-67429",
+      "targets": [
         {
-          "current": {
-            "selected": false,
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 2,
+          "rawSql": "SELECT TOP ${number_of_logs} TIMESTAMP, CONCAT(RECORD:\"severity_text\", ': ', VALUE) AS LOG, * EXCLUDE (TIMESTAMP, VALUE, RECORD)\n  FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "...",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Queries"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#1d8bb7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Hits"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4fb07ce6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Miss"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#b59151eb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Prefetch"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4fb07ce6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expired"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#a871a7f0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(*) AS \" Number of Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": 1800000,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 21,
+        "x": 3,
+        "y": 7
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0-65875",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT DATE_TRUNC(${time_series_division:singlequote}, \"TIMESTAMP\") AS \"Time\", COUNT_IF(RECORD:\"severity_text\"='TRACE') AS \"TRACE\", COUNT_IF(RECORD:\"severity_text\"='DEBUG') AS \"DEBUG\", COUNT_IF(RECORD:\"severity_text\"='INFO') AS \"INFO\", COUNT_IF(RECORD:\"severity_text\"='WARN') AS \"WARN\", COUNT_IF(RECORD:\"severity_text\"='ERROR') AS \"ERROR\", COUNT_IF(RECORD:\"severity_text\"='FATAL') AS \"FATAL\"\n\tFROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP ASC)\n\tGROUP BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\")\n\tORDER BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\");",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"db.user\") AS \"Unique DB Users in Logs\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+          "refId": "A"
+        }
+      ],
+      "title": "Users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 21,
+        "x": 3,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": [],
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeat": "severity_sort_user",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"db.user\"::string AS \"User\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"db.user\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by User",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 23
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\") AS \"Number of Unique Warehouses in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+          "refId": "A"
+        }
+      ],
+      "title": "Warehouses",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": true,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 21,
+        "x": 3,
+        "y": 23
+      },
+      "id": 20,
+      "maxPerRow": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"::string AS \"Warehouse Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC) \n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Warehouse",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 0,
+        "y": 30
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\") AS \"Number of Unique Executable Names in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executables",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": true,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 21,
+        "x": 3,
+        "y": 30
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeat": "severity_sort_executable",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.executable.name\"::string AS \"Executable Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.executable.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Executable",
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+          "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
+        },
+        "description": "The name of the Event Table to query telemetry information from.",
+        "hide": 0,
+        "label": "Event Table",
+        "name": "event_table",
+        "options": [
+          {
+            "selected": true,
             "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
             "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-          },
-          "description": "The name of the Event Table to query telemetry information from.",
-          "hide": 0,
-          "label": "Event Table",
-          "name": "event_table",
-          "options": [
-            {
-              "selected": true,
-              "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-              "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-            }
-          ],
-          "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-          "skipUrlSync": false,
-          "type": "textbox"
+          }
+        ],
+        "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "100",
+          "value": "100"
         },
-        {
-          "current": {
-            "selected": false,
+        "description": "10",
+        "hide": 0,
+        "label": "Number of Logs",
+        "name": "number_of_logs",
+        "options": [
+          {
+            "selected": true,
             "text": "100",
             "value": "100"
-          },
-          "description": "10",
-          "hide": 0,
-          "label": "Number of Logs",
-          "name": "number_of_logs",
-          "options": [
-            {
-              "selected": true,
-              "text": "100",
-              "value": "100"
-            }
-          ],
-          "query": "100",
-          "skipUrlSync": false,
-          "type": "textbox"
+          }
+        ],
+        "query": "100",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "michelin-snowflake-datasource",
-            "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "michelin-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Users",
-          "multi": true,
-          "name": "users",
-          "options": [],
-          "query": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Users",
+        "multi": true,
+        "name": "users",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "michelin-snowflake-datasource",
-            "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "michelin-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Warehouses",
-          "multi": true,
-          "name": "warehouses",
-          "options": [],
-          "query": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "michelin-snowflake-datasource",
-            "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "michelin-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Executables",
-          "multi": true,
-          "name": "executables",
-          "options": [],
-          "query": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Warehouses",
+        "multi": true,
+        "name": "warehouses",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);"
         },
-        {
-          "allValue": "",
-          "current": {},
-          "datasource": {
-            "type": "michelin-snowflake-datasource",
-            "uid": "${DS_MICHELIN-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "michelin-snowflake-datasource Query : SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Severity Levels",
-          "multi": true,
-          "name": "severity_levels",
-          "options": [],
-          "query": "SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
-        {
-          "current": {
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Executables",
+        "multi": true,
+        "name": "executables",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
+        },
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
+        },
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Severity Levels",
+        "multi": true,
+        "name": "severity_levels",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
+        },
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "HOUR",
+          "value": "HOUR"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Time Interval",
+        "multi": false,
+        "name": "time_series_division",
+        "options": [
+          {
             "selected": false,
+            "text": "SECOND",
+            "value": "SECOND"
+          },
+          {
+            "selected": false,
+            "text": "MINUTE",
+            "value": "MINUTE"
+          },
+          {
+            "selected": true,
             "text": "HOUR",
             "value": "HOUR"
           },
-          "hide": 0,
-          "includeAll": false,
-          "label": "Time Interval",
-          "multi": false,
-          "name": "time_series_division",
-          "options": [
-            {
-              "selected": false,
-              "text": "SECOND",
-              "value": "SECOND"
-            },
-            {
-              "selected": false,
-              "text": "MINUTE",
-              "value": "MINUTE"
-            },
-            {
-              "selected": true,
-              "text": "HOUR",
-              "value": "HOUR"
-            },
-            {
-              "selected": false,
-              "text": "DAY",
-              "value": "DAY"
-            },
-            {
-              "selected": false,
-              "text": "MONTH",
-              "value": "MONTH"
-            },
-            {
-              "selected": false,
-              "text": "YEAR",
-              "value": "YEAR"
-            }
-          ],
-          "query": "SECOND,MINUTE,HOUR,DAY,MONTH,YEAR",
-          "queryValue": "",
-          "skipUrlSync": false,
-          "type": "custom"
-        }
-      ]
-    },
-    "time": {
-      "from": "2024-03-04T21:30:00.500Z",
-      "to": "2024-03-05T11:29:58.500Z"
-    },
-    "timepicker": {},
-    "timezone": "",
-    "title": "Logs Dashboard",
-    "version": 1,
-    "weekStart": ""
-  }
+          {
+            "selected": false,
+            "text": "DAY",
+            "value": "DAY"
+          },
+          {
+            "selected": false,
+            "text": "MONTH",
+            "value": "MONTH"
+          },
+          {
+            "selected": false,
+            "text": "YEAR",
+            "value": "YEAR"
+          }
+        ],
+        "query": "SECOND,MINUTE,HOUR,DAY,MONTH,YEAR",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "2024-03-04T21:30:00.500Z",
+    "to": "2024-03-05T11:29:58.500Z"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "",
+  "title": "Logs Dashboard",
+  "uid": "431d22e3d526",
+  "version": 21,
+  "weekStart": ""
+}

--- a/open_source/logs.json
+++ b/open_source/logs.json
@@ -15,13 +15,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.0.0-67746"
+      "version": "11.1.0-70903"
     },
     {
       "type": "datasource",
       "id": "grafana-snowflake-datasource",
       "name": "Snowflake",
-      "version": "1.8.1"
+      "version": "1.7.1"
     },
     {
       "type": "panel",
@@ -245,7 +245,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -405,7 +405,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -496,7 +496,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "repeat": "severity_sort_user",
       "repeatDirection": "h",
       "targets": [
@@ -563,7 +563,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -652,7 +652,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "repeatDirection": "h",
       "targets": [
         {
@@ -683,8 +683,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -718,7 +717,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "targets": [
         {
           "datasource": {
@@ -759,8 +758,7 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -806,7 +804,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "11.1.0-70903",
       "repeat": "severity_sort_executable",
       "repeatDirection": "h",
       "targets": [
@@ -830,25 +828,49 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-          "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
         },
-        "description": "The name of the Event Table to query telemetry information from.",
-        "hide": 0,
-        "label": "Event Table",
-        "name": "event_table",
-        "options": [
-          {
-            "selected": true,
-            "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-            "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-          }
-        ],
-        "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+        "definition": "grafana-snowflake-datasource Query :  show parameters like 'event_table' in account;\n",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "show_event_table",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "show parameters like 'event_table' in account;\n"
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "textbox"
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        },
+        "definition": "grafana-snowflake-datasource Query :  select \"value\" \nfrom table(result_scan(last_query_id()))\n--where '${show_event_table}' is not null;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "active_event_table",
+        "multi": false,
+        "name": "event_table",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "select \"value\" \nfrom table(result_scan(last_query_id()))\n--where '${show_event_table}' is not null;"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
         "current": {
@@ -966,7 +988,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "HOUR",
           "value": "HOUR"
         },
@@ -1021,8 +1043,8 @@
   "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "",
-  "title": "Logs Dashboard",
-  "uid": "431d22e3d526",
-  "version": 21,
+  "title": "Logs v2",
+  "uid": "431d22e3d5262",
+  "version": 5,
   "weekStart": ""
 }

--- a/open_source/snowpark-metrics.json
+++ b/open_source/snowpark-metrics.json
@@ -29,7 +29,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.1.0-69622"
+      "version": "11.1.0-69950"
     },
     {
       "type": "datasource",
@@ -118,7 +118,7 @@
         "content": "## Snowpark Metrics Dashboard\n\nThis dashboard visualizes Snowpark-related metrics in the Snowflake Event Table. \nMany operations require the queryer to have the `ACCOUNTADMIN` role.\n\nTo do this securely, you can create a new grafana datasource that has a user with the `ACCOUNTADMIN` role, and select that datasource in the variables above.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -165,7 +165,7 @@
         "content": "Select the `Database` and `Schema` variables to view the active functions and procedures.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -222,7 +222,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -281,7 +281,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -349,7 +349,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -398,7 +398,7 @@
         "content": "Fill in the `Function Name` variable to view Memory and CPU metrics for this function or procedure.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69622",
+      "pluginVersion": "11.1.0-69950",
       "targets": [
         {
           "datasource": {
@@ -458,7 +458,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -496,7 +497,7 @@
             "uid": "${DS_SNOWFLAKE}"
           },
           "format": 0,
-          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as memory_usage_bytes\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    CASE \n      WHEN record['value_type'] = 'INT' THEN value::INT\n      WHEN record['value_type'] = 'DOUBLE' THEN value::DOUBLE\n    END as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${memory_usage}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;",
+          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as memory_usage_bytes\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    value::INT as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${memory_usage}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;",
           "refId": "A"
         }
       ],
@@ -546,13 +547,12 @@
             }
           },
           "mappings": [],
-          "max": 1,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -590,7 +590,7 @@
             "uid": "${DS_SNOWFLAKE}"
           },
           "format": 0,
-          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as CPU_UTIL_PCT\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    CASE \n      WHEN record['value_type'] = 'INT' THEN value::INT\n      WHEN record['value_type'] = 'DOUBLE' THEN value::DOUBLE\n    END as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${cpu_util}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;\n  ",
+          "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as CPU_UTIL_PCT\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp, \n    value::DOUBLE as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${cpu_util}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;\n  ",
           "refId": "A"
         }
       ],
@@ -784,6 +784,6 @@
   "timezone": "",
   "title": "Snowpark Metrics Dashboard",
   "uid": "fdivgoharm0owc",
-  "version": 67,
+  "version": 68,
   "weekStart": ""
 }

--- a/open_source/snowpark-metrics.json
+++ b/open_source/snowpark-metrics.json
@@ -1,7 +1,7 @@
 {
   "__inputs": [
     {
-      "name": "DS_MICHELIN-SNOWFLAKE-DATASOURCE",
+      "name": "DS_GRAFANA_SNOWFLAKE_DATASOURCE",
       "label": "michelin-snowflake-datasource",
       "description": "",
       "type": "datasource",
@@ -227,7 +227,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 1,
           "rawSql": "SELECT\n    count(DISTINCT FUNCTION_NAME)\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS\nWHERE TRUE \n  AND DELETED IS NULL\n  AND FUNCTION_CATALOG = '${database}';",
@@ -286,7 +286,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 1,
           "rawSql": "SELECT\n    count(DISTINCT PROCEDURE_NAME)\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES\nWHERE TRUE \n  AND DELETED IS NULL\n  AND PROCEDURE_CATALOG = '${database}';",
@@ -354,7 +354,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 1,
           "rawSql": "SELECT DISTINCT\n    'PROCEDURE' as  type, PROCEDURE_NAME as name, PROCEDURE_LANGUAGE as language, RUNTIME_VERSION, LAST_ALTERED\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES\nWHERE TRUE \n  AND DELETED IS NULL\n  AND PROCEDURE_CATALOG = '${database}'\n  AND PROCEDURE_SCHEMA = '${schema}'\n  AND PROCEDURE_LANGUAGE in ('PYTHON', 'JAVA', 'JAVASCRIPT')\nUNION\nSELECT\n    DISTINCT 'FUNCTION' as  type, FUNCTION_NAME as name, FUNCTION_LANGUAGE as language, RUNTIME_VERSION, LAST_ALTERED\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS\nWHERE TRUE \n  AND DELETED IS NULL\n  AND FUNCTION_CATALOG = '${database}'\n  AND FUNCTION_SCHEMA = '${schema}'\n  AND FUNCTION_LANGUAGE in ('PYTHON', 'JAVA', 'JAVASCRIPT')\nORDER BY 1, 2;",
@@ -414,7 +414,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_SNOWFLAKE}"
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
       },
       "fieldConfig": {
         "defaults": {
@@ -494,7 +494,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 0,
           "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as memory_usage_bytes\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    value::INT as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${memory_usage}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;",
@@ -507,7 +507,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_SNOWFLAKE}"
+        "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
       },
       "fieldConfig": {
         "defaults": {
@@ -587,7 +587,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
           },
           "format": 0,
           "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as CPU_UTIL_PCT\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp, \n    value::DOUBLE as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${cpu_util}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;\n  ",
@@ -626,7 +626,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  show parameters like 'event_table' in account;",
         "hide": 2,
@@ -649,7 +649,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  SELECT \"value\" \nFROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))\nwhere '${show_event_table}' is not null;\n",
         "hide": 0,
@@ -711,7 +711,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  select distinct database_name from snowflake.account_usage.databases where DELETED is null;",
         "hide": 0,
@@ -734,7 +734,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${DS_GRAFANA_SNOWFLAKE_DATASOURCE}"
         },
         "definition": "snowflake Query :  select schema_name from snowflake.account_usage.schemata \nwhere deleted is null\nand catalog_name = '${database}';",
         "hide": 0,


### PR DESCRIPTION
###  Changes from https://github.com/snowflakedb/snowflake-telemetry-dashboard-templates/pull/6 
Before:

DS_GRAFANA-SNOWFLAKE-DATASOURCE was the name for the __inputs variable, however it was trying to get read as DS_SNOWFLAKE so due to the mismatch importing and using the dashboards would fail.

Renamed the variable to: DS_GRAFANA_SNOWFLAKE_DATASOURCE (all underscores)


### Updated default `event_table` variable value 
Before: 
The default value of `event_table` is `GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table`, which is invalid.
However many other variables such as `severity_level`, `db.user`, etc depend on this variable, and thus the generated SQL query to fetch logs data is invalid and returns syntax error on launching the dashboard. This is not a good user experience.

Updated the `event_table` variable to be pre-populated with current active event table returned from `show parameters like `event_table` in acccount;`. 



