### PR TITLE
[Snowflake] Enterprise metrics tweak

### DIFF
--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -1,1027 +1,1013 @@
 {
-    "__inputs": [
-      {
-        "name": "DS_GRAFANA-SNOWFLAKE-DATASOURCE",
-        "label": "grafana-snowflake-datasource",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "grafana-snowflake-datasource",
-        "pluginName": "Snowflake"
-      }
-    ],
-    "__elements": {},
-    "__requires": [
-      {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "11.0.0-67746"
-      },
-      {
-        "type": "datasource",
-        "id": "grafana-snowflake-datasource",
-        "name": "Snowflake",
-        "version": "1.8.1"
-      },
-      {
-        "type": "panel",
-        "id": "logs",
-        "name": "Logs",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "stat",
-        "name": "Stat",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "table",
-        "name": "Table",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "timeseries",
-        "name": "Time series",
-        "version": ""
-      }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
+  "__inputs": [
+    {
+      "name": "DS_GRAFANA-SNOWFLAKE-DATASOURCE",
+      "label": "grafana-snowflake-datasource",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "grafana-snowflake-datasource",
+      "pluginName": "Snowflake"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0-67746"
     },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": null,
-    "links": [],
-    "liveNow": false,
-    "panels": [
+    {
+      "type": "datasource",
+      "id": "grafana-snowflake-datasource",
+      "name": "Snowflake",
+      "version": "1.8.1"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
       {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 4,
-        "panels": [],
-        "type": "row"
-      },
-      {
+        "builtIn": 1,
         "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          "type": "grafana",
+          "uid": "-- Grafana --"
         },
-        "description": "",
-        "gridPos": {
-          "h": 6,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 1,
-        "options": {
-          "dedupStrategy": "none",
-          "enableLogDetails": true,
-          "prettifyLogMessage": true,
-          "showCommonLabels": false,
-          "showLabels": false,
-          "showTime": true,
-          "sortOrder": "Descending",
-          "wrapLogMessage": false
-        },
-        "pluginVersion": "11.0.0-67429",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 2,
-            "rawSql": "SELECT TOP ${number_of_logs} TIMESTAMP, CONCAT(RECORD:\"severity_text\", ': ', VALUE) AS LOG, * EXCLUDE (TIMESTAMP, VALUE, RECORD)\n  FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs",
-        "type": "logs"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "noValue": "...",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "locale"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Total Queries"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#1d8bb7",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cache Hits"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#4fb07ce6",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Cache Miss"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#b59151eb",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Prefetch"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#4fb07ce6",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Expired"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "#a871a7f0",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 3,
-          "x": 0,
-          "y": 7
-        },
-        "id": 2,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(*) AS \" Number of Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": 1800000,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "noValue": "0",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 21,
-          "x": 3,
-          "y": 7
-        },
-        "id": 9,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "10.4.0-65875",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT DATE_TRUNC(${time_series_division:singlequote}, \"TIMESTAMP\") AS \"Time\", COUNT_IF(RECORD:\"severity_text\"='TRACE') AS \"TRACE\", COUNT_IF(RECORD:\"severity_text\"='DEBUG') AS \"DEBUG\", COUNT_IF(RECORD:\"severity_text\"='INFO') AS \"INFO\", COUNT_IF(RECORD:\"severity_text\"='WARN') AS \"WARN\", COUNT_IF(RECORD:\"severity_text\"='ERROR') AS \"ERROR\", COUNT_IF(RECORD:\"severity_text\"='FATAL') AS \"FATAL\"\n\tFROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP ASC)\n\tGROUP BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\")\n\tORDER BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\");",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs over Time",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 3,
-          "x": 0,
-          "y": 16
-        },
-        "id": 7,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"db.user\") AS \"Unique DB Users in Logs\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-            "refId": "A"
-          }
-        ],
-        "title": "Users",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": false,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "mode": "gradient",
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 21,
-          "x": 3,
-          "y": 16
-        },
-        "id": 11,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "enablePagination": false,
-            "fields": [],
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": []
-        },
-        "pluginVersion": "11.0.0-67746",
-        "repeat": "severity_sort_user",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"db.user\"::string AS \"User\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"db.user\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by User",
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 3,
-          "x": 0,
-          "y": 23
-        },
-        "id": 19,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\") AS \"Number of Unique Warehouses in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-            "refId": "A"
-          }
-        ],
-        "title": "Warehouses",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": true,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 21,
-          "x": 3,
-          "y": 23
-        },
-        "id": 20,
-        "maxPerRow": 3,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"::string AS \"Warehouse Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC) \n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by Warehouse",
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 3,
-          "x": 0,
-          "y": 30
-        },
-        "id": 18,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\") AS \"Number of Unique Executable Names in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-            "refId": "A"
-          }
-        ],
-        "title": "Executables",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-        },
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "color-text"
-              },
-              "filterable": true,
-              "inspect": true
-            },
-            "fieldMinMax": true,
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Count"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 21,
-          "x": 3,
-          "y": 30
-        },
-        "id": 14,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true
-        },
-        "pluginVersion": "11.0.0-67746",
-        "repeat": "severity_sort_executable",
-        "repeatDirection": "h",
-        "targets": [
-          {
-            "datasource": {
-              "type": "grafana-snowflake-datasource",
-              "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-            },
-            "format": 0,
-            "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.executable.name\"::string AS \"Executable Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.executable.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
-            "refId": "A"
-          }
-        ],
-        "title": "Logs by Executable",
-        "type": "table"
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "refresh": "",
-    "schemaVersion": 39,
-    "tags": [],
-    "templating": {
-      "list": [
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "panels": [],
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.0.0-67429",
+      "targets": [
         {
-          "current": {
-            "selected": false,
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 2,
+          "rawSql": "SELECT TOP ${number_of_logs} TIMESTAMP, CONCAT(RECORD:\"severity_text\", ': ', VALUE) AS LOG, * EXCLUDE (TIMESTAMP, VALUE, RECORD)\n  FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "noValue": "...",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "locale"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Queries"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#1d8bb7",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Hits"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4fb07ce6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Miss"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#b59151eb",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Prefetch"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#4fb07ce6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expired"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#a871a7f0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(*) AS \" Number of Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": 1800000,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 21,
+        "x": 3,
+        "y": 7
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0-65875",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT DATE_TRUNC(${time_series_division:singlequote}, \"TIMESTAMP\") AS \"Time\", COUNT_IF(RECORD:\"severity_text\"='TRACE') AS \"TRACE\", COUNT_IF(RECORD:\"severity_text\"='DEBUG') AS \"DEBUG\", COUNT_IF(RECORD:\"severity_text\"='INFO') AS \"INFO\", COUNT_IF(RECORD:\"severity_text\"='WARN') AS \"WARN\", COUNT_IF(RECORD:\"severity_text\"='ERROR') AS \"ERROR\", COUNT_IF(RECORD:\"severity_text\"='FATAL') AS \"FATAL\"\n\tFROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP ASC)\n\tGROUP BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\")\n\tORDER BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\");",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"db.user\") AS \"Unique DB Users in Logs\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+          "refId": "A"
+        }
+      ],
+      "title": "Users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 21,
+        "x": 3,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": [],
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeat": "severity_sort_user",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"db.user\"::string AS \"User\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"db.user\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by User",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 0,
+        "y": 23
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\") AS \"Number of Unique Warehouses in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+          "refId": "A"
+        }
+      ],
+      "title": "Warehouses",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": true,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 21,
+        "x": 3,
+        "y": 23
+      },
+      "id": 20,
+      "maxPerRow": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"::string AS \"Warehouse Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC) \n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Warehouse",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 0,
+        "y": 30
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\") AS \"Number of Unique Executable Names in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Executables",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-snowflake-datasource",
+        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "filterable": true,
+            "inspect": true
+          },
+          "fieldMinMax": true,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 21,
+        "x": 3,
+        "y": 30
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0-67746",
+      "repeat": "severity_sort_executable",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-snowflake-datasource",
+            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          },
+          "format": 0,
+          "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.executable.name\"::string AS \"Executable Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.executable.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs by Executable",
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+          "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
+        },
+        "description": "The name of the Event Table to query telemetry information from.",
+        "hide": 0,
+        "label": "Event Table",
+        "name": "event_table",
+        "options": [
+          {
+            "selected": true,
             "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
             "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-          },
-          "description": "The name of the Event Table to query telemetry information from.",
-          "hide": 0,
-          "label": "Event Table",
-          "name": "event_table",
-          "options": [
-            {
-              "selected": true,
-              "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-              "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-            }
-          ],
-          "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-          "skipUrlSync": false,
-          "type": "textbox"
+          }
+        ],
+        "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "100",
+          "value": "100"
         },
-        {
-          "current": {
-            "selected": false,
+        "description": "10",
+        "hide": 0,
+        "label": "Number of Logs",
+        "name": "number_of_logs",
+        "options": [
+          {
+            "selected": true,
             "text": "100",
             "value": "100"
-          },
-          "description": "10",
-          "hide": 0,
-          "label": "Number of Logs",
-          "name": "number_of_logs",
-          "options": [
-            {
-              "selected": true,
-              "text": "100",
-              "value": "100"
-            }
-          ],
-          "query": "100",
-          "skipUrlSync": false,
-          "type": "textbox"
+          }
+        ],
+        "query": "100",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Users",
-          "multi": true,
-          "name": "users",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Users",
+        "multi": true,
+        "name": "users",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Warehouses",
-          "multi": true,
-          "name": "warehouses",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
         },
-        {
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Executables",
-          "multi": true,
-          "name": "executables",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Warehouses",
+        "multi": true,
+        "name": "warehouses",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);"
         },
-        {
-          "allValue": "",
-          "current": {},
-          "datasource": {
-            "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
-          },
-          "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Severity Levels",
-          "multi": true,
-          "name": "severity_levels",
-          "options": [],
-          "query": {
-            "format": 1,
-            "rawSql": "SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
-          },
-          "refresh": 1,
-          "regex": "\"(.*)\"",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
         },
-        {
-          "current": {
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Executables",
+        "multi": true,
+        "name": "executables",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
+        },
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        },
+        "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Severity Levels",
+        "multi": true,
+        "name": "severity_levels",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n"
+        },
+        "refresh": 1,
+        "regex": "\"(.*)\"",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "HOUR",
+          "value": "HOUR"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Time Interval",
+        "multi": false,
+        "name": "time_series_division",
+        "options": [
+          {
+            "selected": false,
+            "text": "SECOND",
+            "value": "SECOND"
+          },
+          {
+            "selected": false,
+            "text": "MINUTE",
+            "value": "MINUTE"
+          },
+          {
             "selected": true,
             "text": "HOUR",
             "value": "HOUR"
           },
-          "hide": 0,
-          "includeAll": false,
-          "label": "Time Interval",
-          "multi": false,
-          "name": "time_series_division",
-          "options": [
-            {
-              "selected": false,
-              "text": "SECOND",
-              "value": "SECOND"
-            },
-            {
-              "selected": false,
-              "text": "MINUTE",
-              "value": "MINUTE"
-            },
-            {
-              "selected": true,
-              "text": "HOUR",
-              "value": "HOUR"
-            },
-            {
-              "selected": false,
-              "text": "DAY",
-              "value": "DAY"
-            },
-            {
-              "selected": false,
-              "text": "MONTH",
-              "value": "MONTH"
-            },
-            {
-              "selected": false,
-              "text": "YEAR",
-              "value": "YEAR"
-            }
-          ],
-          "query": "SECOND,MINUTE,HOUR,DAY,MONTH,YEAR",
-          "queryValue": "",
-          "skipUrlSync": false,
-          "type": "custom"
-        }
-      ]
-    },
-    "time": {
-      "from": "2024-03-04T21:30:00.500Z",
-      "to": "2024-03-05T11:29:58.500Z"
-    },
-    "timeRangeUpdatedDuringEditOrView": false,
-    "timepicker": {},
-    "timezone": "",
-    "title": "Logs Dashboard",
-    "version": 21,
-    "weekStart": ""
-  }
+          {
+            "selected": false,
+            "text": "DAY",
+            "value": "DAY"
+          },
+          {
+            "selected": false,
+            "text": "MONTH",
+            "value": "MONTH"
+          },
+          {
+            "selected": false,
+            "text": "YEAR",
+            "value": "YEAR"
+          }
+        ],
+        "query": "SECOND,MINUTE,HOUR,DAY,MONTH,YEAR",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "2024-03-04T21:30:00.500Z",
+    "to": "2024-03-05T11:29:58.500Z"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "",
+  "title": "Logs Dashboard",
+  "version": 21,
+  "weekStart": ""
+}

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -994,8 +994,8 @@
     ]
   },
   "time": {
-    "from": "2024-03-04T21:30:00.500Z",
-    "to": "2024-03-05T11:29:58.500Z"
+    "from": "now-5y",
+    "to": "now"
   },
   "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -818,16 +818,16 @@
         "label": "active_event_table",
         "multi": false,
         "name": "event_table",
-        "options": [
-          {
-            "selected": true,
-            "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-            "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
-          }
-        ],
-        "query": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "select \"value\" \nfrom table(result_scan(last_query_id()))\n--where '${show_event_table}' is not null;"
+        },
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "textbox"
+        "sort": 0,
+        "type": "query"
       },
       {
         "current": {

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -1,14 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_GRAFANA-SNOWFLAKE-DATASOURCE",
-      "label": "grafana-snowflake-datasource",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "grafana-snowflake-datasource",
-      "pluginName": "Snowflake"
-    }
-  ],
   "__elements": {},
   "__requires": [
     {

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -784,6 +784,39 @@
         "skipUrlSync": false,
         "type": "datasource"
       },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${datasource}"
+        },
+        "definition": "grafana-snowflake-datasource Query :  show parameters like 'event_table' in account;\n",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "show_event_table",
+        "options": [],
+        "query": {
+          "format": 1,
+          "rawSql": "show parameters like 'event_table' in account;\n"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "grafana-snowflake-datasource",
+          "uid": "${datasource}"
+        },
+        "definition": "grafana-snowflake-datasource Query :  select \"value\" \nfrom table(result_scan(last_query_id()))\n--where '${show_event_table}' is not null;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "active_event_table",
+        "multi": false,
         "name": "event_table",
         "options": [
           {

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -1,43 +1,4 @@
 {
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "11.0.0-67746"
-    },
-    {
-      "type": "datasource",
-      "id": "grafana-snowflake-datasource",
-      "name": "Snowflake",
-      "version": "1.8.1"
-    },
-    {
-      "type": "panel",
-      "id": "logs",
-      "name": "Logs",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -945,7 +945,7 @@
       },
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "HOUR",
           "value": "HOUR"
         },

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -194,7 +194,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -352,7 +352,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -441,7 +441,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "9.5.13",
       "repeat": "severity_sort_user",
       "repeatDirection": "h",
       "targets": [
@@ -506,7 +506,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -593,7 +593,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "9.5.13",
       "repeatDirection": "h",
       "targets": [
         {
@@ -657,7 +657,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -743,7 +743,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0-67746",
+      "pluginVersion": "9.5.13",
       "repeat": "severity_sort_executable",
       "repeatDirection": "h",
       "targets": [

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -37,7 +37,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "description": "",
       "gridPos": {
@@ -62,7 +62,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 2,
           "rawSql": "SELECT TOP ${number_of_logs} TIMESTAMP, CONCAT(RECORD:\"severity_text\", ': ', VALUE) AS LOG, * EXCLUDE (TIMESTAMP, VALUE, RECORD)\n  FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC;",
@@ -75,7 +75,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -199,7 +199,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT COUNT(*) AS \" Number of Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n;",
@@ -212,7 +212,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -294,7 +294,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT DATE_TRUNC(${time_series_division:singlequote}, \"TIMESTAMP\") AS \"Time\", COUNT_IF(RECORD:\"severity_text\"='TRACE') AS \"TRACE\", COUNT_IF(RECORD:\"severity_text\"='DEBUG') AS \"DEBUG\", COUNT_IF(RECORD:\"severity_text\"='INFO') AS \"INFO\", COUNT_IF(RECORD:\"severity_text\"='WARN') AS \"WARN\", COUNT_IF(RECORD:\"severity_text\"='ERROR') AS \"ERROR\", COUNT_IF(RECORD:\"severity_text\"='FATAL') AS \"FATAL\"\n\tFROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP ASC)\n\tGROUP BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\")\n\tORDER BY DATE_TRUNC(${time_series_division:doublequote}, \"TIMESTAMP\");",
@@ -307,7 +307,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -357,7 +357,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"db.user\") AS \"Unique DB Users in Logs\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
@@ -370,7 +370,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -448,7 +448,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"db.user\"::string AS \"User\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM \n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"db.user\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
@@ -461,7 +461,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -511,7 +511,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\") AS \"Number of Unique Warehouses in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
@@ -524,7 +524,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -599,7 +599,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"::string AS \"Warehouse Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC) \n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
@@ -612,7 +612,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -662,7 +662,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT COUNT(DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\") AS \"Number of Unique Executable Names in Logs\" \n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
@@ -675,7 +675,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -750,7 +750,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "SELECT RESOURCE_ATTRIBUTES:\"snow.executable.name\"::string AS \"Executable Name\", COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) AS \"Count\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RECORD:\"severity_text\" IN (${severity_levels:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC)\n  GROUP BY RESOURCE_ATTRIBUTES:\"snow.executable.name\" \n  ORDER BY COUNT_IF(RECORD:\"severity_text\" IN (${severity_levels:singlequote})) DESC;",
@@ -769,12 +769,21 @@
       {
         "current": {
           "selected": false,
-          "text": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table",
-          "value": "GRAFANA_TEST_DATABASE.GRAFANA_TEST_EVENT_TABLE.grafana_test_event_table"
+          "text": "",
+          "value": ""
         },
-        "description": "The name of the Event Table to query telemetry information from.",
         "hide": 0,
-        "label": "Event Table",
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "grafana-snowflake-datasource",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
         "name": "event_table",
         "options": [
           {
@@ -812,7 +821,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          "uid": "${datasource}"
         },
         "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"db.user\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
         "hide": 0,
@@ -835,7 +844,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          "uid": "${datasource}"
         },
         "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.warehouse.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);",
         "hide": 0,
@@ -858,7 +867,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          "uid": "${datasource}"
         },
         "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RESOURCE_ATTRIBUTES:\"snow.executable.name\"\n  FROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
         "hide": 0,
@@ -882,7 +891,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_GRAFANA-SNOWFLAKE-DATASOURCE}"
+          "uid": "${datasource}"
         },
         "definition": "grafana-snowflake-datasource Query : SELECT DISTINCT RECORD:\"severity_text\" AS __value\nFROM\n  (SELECT TOP ${number_of_logs} * FROM ${event_table} \n  WHERE ${event_table}.RECORD_TYPE='LOG'\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"db.user\" IN (${users:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.warehouse.name\" IN (${warehouses:singlequote})\n  AND ${event_table}.RESOURCE_ATTRIBUTES:\"snow.executable.name\" IN (${executables:singlequote})\n  AND ${event_table}.TIMESTAMP BETWEEN ${__from:singlequote} AND ${__to:singlequote}\n  ORDER BY ${event_table}.TIMESTAMP DESC);\n",
         "hide": 0,

--- a/enterprise/logs.json
+++ b/enterprise/logs.json
@@ -1001,6 +1001,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Logs Dashboard",
-  "version": 21,
+  "uid": "431d22e3d5262",
+  "version": 5,
   "weekStart": ""
 }

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -658,24 +658,24 @@
         "type": "textbox"
       },
       {
-        "hide": 2,
+        "current": {
+          "selected": false,
+          "text": "process.cpu.utilization",
+          "value": "process.cpu.utilization"
+        },
+        "hide": 0,
         "label": "Process CPU utilization",
         "name": "cpu_util",
-        "query": "${VAR_CPU_UTIL}",
-        "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_CPU_UTIL}",
-          "text": "${VAR_CPU_UTIL}",
-          "selected": false
-        },
         "options": [
           {
-            "value": "${VAR_CPU_UTIL}",
-            "text": "${VAR_CPU_UTIL}",
-            "selected": false
+            "selected": true,
+            "text": "process.cpu.utilization",
+            "value": "process.cpu.utilization"
           }
-        ]
+        ],
+        "query": "process.cpu.utilization",
+        "skipUrlSync": false,
+        "type": "textbox"
       },
       {
         "current": {},

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -639,23 +639,23 @@
         "type": "query"
       },
       {
-        "hide": 2,
-        "name": "memory_usage",
-        "query": "${VAR_MEMORY_USAGE}",
-        "skipUrlSync": false,
-        "type": "constant",
         "current": {
-          "value": "${VAR_MEMORY_USAGE}",
-          "text": "${VAR_MEMORY_USAGE}",
-          "selected": false
+          "selected": false,
+          "text": "process.memory.usage",
+          "value": "process.memory.usage"
         },
+        "hide": 0,
+        "name": "memory_usage",
         "options": [
           {
-            "value": "${VAR_MEMORY_USAGE}",
-            "text": "${VAR_MEMORY_USAGE}",
-            "selected": false
+            "selected": true,
+            "text": "process.memory.usage",
+            "value": "process.memory.usage"
           }
-        ]
+        ],
+        "query": "process.memory.usage",
+        "skipUrlSync": false,
+        "type": "textbox"
       },
       {
         "hide": 2,

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -1,48 +1,4 @@
 {
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "11.1.0-69950"
-    },
-    {
-      "type": "datasource",
-      "id": "grafana-snowflake-datasource",
-      "name": "Snowflake",
-      "version": "1.7.1"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -1,28 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_GRAFANA-SNOWFLAKE-DATASOURCE",
-      "label": "grafana-snowflake-datasource",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "grafana-snowflake-datasource",
-      "pluginName": "Snowflake"
-    },
-    {
-      "name": "VAR_MEMORY_USAGE",
-      "type": "constant",
-      "label": "memory_usage",
-      "value": "process.memory.usage",
-      "description": ""
-    },
-    {
-      "name": "VAR_CPU_UTIL",
-      "type": "constant",
-      "label": "Process CPU utilization",
-      "value": "process.cpu.utilization",
-      "description": ""
-    }
-  ],
   "__elements": {},
   "__requires": [
     {

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -112,7 +112,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -169,7 +169,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -226,7 +226,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -212,9 +212,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
+          "calcs": ["mean"],
           "fields": "",
           "values": false
         },
@@ -271,9 +269,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
+          "calcs": ["mean"],
           "fields": "",
           "values": false
         },
@@ -342,9 +338,7 @@
         "footer": {
           "countRows": false,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -94,7 +94,7 @@
         "content": "## Snowpark Metrics Dashboard\n\nThis dashboard visualizes Snowpark-related metrics in the Snowflake Event Table. \nMany operations require the queryer to have the `ACCOUNTADMIN` role.\n\nTo do this securely, you can create a new grafana datasource that has a user with the `ACCOUNTADMIN` role, and select that datasource in the variables above.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69950",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -141,7 +141,7 @@
         "content": "Select the `Database` and `Schema` variables to view the active functions and procedures.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69950",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -196,7 +196,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0-69950",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -253,7 +253,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0-69950",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -319,7 +319,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.1.0-69950",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {
@@ -368,7 +368,7 @@
         "content": "Fill in the `Function Name` variable to view Memory and CPU metrics for this function or procedure.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.1.0-69950",
+      "pluginVersion": "9.5.13",
       "targets": [
         {
           "datasource": {

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -76,7 +76,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-SNOWPARKTEST1-PROM}"
+        "uid": "prometheus"
       },
       "gridPos": {
         "h": 4,
@@ -99,7 +99,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-SNOWPARKTEST1-PROM}"
+            "uid": "prometheus"
           },
           "refId": "A"
         }
@@ -123,7 +123,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-SNOWPARKTEST1-PROM}"
+        "uid": "prometheus"
       },
       "gridPos": {
         "h": 2,
@@ -146,7 +146,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-SNOWPARKTEST1-PROM}"
+            "uid": "prometheus"
           },
           "refId": "A"
         }
@@ -201,7 +201,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "rawSql": "SELECT\n    count(DISTINCT FUNCTION_NAME)\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS\nWHERE TRUE \n  AND DELETED IS NULL\n  AND FUNCTION_CATALOG = '${database}';",
@@ -258,7 +258,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "rawSql": "SELECT\n    count(DISTINCT PROCEDURE_NAME)\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES\nWHERE TRUE \n  AND DELETED IS NULL\n  AND PROCEDURE_CATALOG = '${database}';",
@@ -324,7 +324,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${datasource}"
           },
           "format": 1,
           "rawSql": "SELECT DISTINCT\n    'PROCEDURE' as  type, PROCEDURE_NAME as name, PROCEDURE_LANGUAGE as language, RUNTIME_VERSION, LAST_ALTERED\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES\nWHERE TRUE \n  AND DELETED IS NULL\n  AND PROCEDURE_CATALOG = '${database}'\n  AND PROCEDURE_SCHEMA = '${schema}'\n  AND PROCEDURE_LANGUAGE in ('PYTHON', 'JAVA', 'JAVASCRIPT')\nUNION\nSELECT\n    DISTINCT 'FUNCTION' as  type, FUNCTION_NAME as name, FUNCTION_LANGUAGE as language, RUNTIME_VERSION, LAST_ALTERED\nFROM\n    SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS\nWHERE TRUE \n  AND DELETED IS NULL\n  AND FUNCTION_CATALOG = '${database}'\n  AND FUNCTION_SCHEMA = '${schema}'\n  AND FUNCTION_LANGUAGE in ('PYTHON', 'JAVA', 'JAVASCRIPT')\nORDER BY 1, 2;",
@@ -350,7 +350,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_GRAFANACLOUD-SNOWPARKTEST1-PROM}"
+        "uid": "prometheus"
       },
       "gridPos": {
         "h": 2,
@@ -373,7 +373,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_GRAFANACLOUD-SNOWPARKTEST1-PROM}"
+            "uid": "prometheus"
           },
           "refId": "A"
         }
@@ -384,7 +384,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_SNOWFLAKE}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -464,7 +464,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as memory_usage_bytes\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp,\n    value::INT as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${memory_usage}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;",
@@ -477,7 +477,7 @@
     {
       "datasource": {
         "type": "grafana-snowflake-datasource",
-        "uid": "${DS_SNOWFLAKE}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -557,7 +557,7 @@
         {
           "datasource": {
             "type": "grafana-snowflake-datasource",
-            "uid": "${DS_SNOWFLAKE}"
+            "uid": "${datasource}"
           },
           "format": 0,
           "rawSql": "select $__timeGroup(timestamp::TIMESTAMP_NTZ, $__interval) as ts, \nmax(value) as CPU_UTIL_PCT\nfrom \n  (\n    SELECT  \n    resource_attributes['snow.executable.name'] as function,\n    timestamp, \n    value::DOUBLE as value\n  FROM ${event_table}\n  WHERE TRUE\n     AND RECORD_TYPE = 'METRIC'\n\t\t AND record['metric']['name'] = '${cpu_util}'\n     AND resource_attributes['snow.database.name'] = '${database}'\n     AND resource_attributes['snow.schema.name'] = '${schema}'\n\t\t AND resource_attributes['snow.executable.name'] ilike '%${function}%'\n\t)\n  group by 1\n  ;\n  ",
@@ -596,7 +596,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${datasource}"
         },
         "definition": "snowflake Query :  show parameters like 'event_table' in account;",
         "hide": 2,
@@ -619,7 +619,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${datasource}"
         },
         "definition": "snowflake Query :  SELECT \"value\" \nFROM TABLE(RESULT_SCAN(LAST_QUERY_ID()))\nwhere '${show_event_table}' is not null;\n",
         "hide": 0,
@@ -681,7 +681,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${datasource}"
         },
         "definition": "snowflake Query :  select distinct database_name from snowflake.account_usage.databases where DELETED is null;",
         "hide": 0,
@@ -704,7 +704,7 @@
         "current": {},
         "datasource": {
           "type": "grafana-snowflake-datasource",
-          "uid": "${DS_SNOWFLAKE}"
+          "uid": "${datasource}"
         },
         "definition": "snowflake Query :  select schema_name from snowflake.account_usage.schemata \nwhere deleted is null\nand catalog_name = '${database}';",
         "hide": 0,

--- a/enterprise/snowpark-metrics.json
+++ b/enterprise/snowpark-metrics.json
@@ -1,5 +1,4 @@
 {
-  "__elements": {},
   "__requires": [
     {
       "type": "grafana",


### PR DESCRIPTION
This makes the snowpark-metrics dashboard work when being imported straight from the plugin page in grafana.

- Format the JSON with prettier
- Removes `__inputs` field as they don't work with dashboards imported in this way
- Moves those variables to dashboard variables
- Downgrade minimum grafana version required from 11 to 9 to match the same min version supported by the plugin on grafana

https://github.com/snowflakedb/snowflake-telemetry-dashboard-templates/assets/7088511/b536ca97-ba6f-4436-8692-2b1520bb7c9a

Logs dashboard
![image](https://github.com/snowflakedb/snowflake-telemetry-dashboard-templates/assets/7088511/81ab127c-c4c1-4e99-8cb5-d976af61dec7)

